### PR TITLE
bug(typo): Fix typo in the tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3665,7 +3665,7 @@ resource cleanup when possible.
 
 ## Tools
 
-Here's some tools to help you automatically check Ruby code against
+Here are some tools to help you automatically check Ruby code against
 this guide.
 
 ### RuboCop


### PR DESCRIPTION
'Here's some tools' is incorrect as we are referring to more than one tools.